### PR TITLE
Send metrics to different Datadog Servers based on DD_SITE environment variable

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -80,7 +80,15 @@ const submitMetrics = async (series: Series[], inputs: Inputs) => {
   core.startGroup(`Send metrics to Datadog ${dryRun ? '(dry-run)' : ''}`)
   core.info(JSON.stringify(series, undefined, 2))
   if (!dryRun) {
-    const metrics = new v1.MetricsApi(v1.createConfiguration({ authMethods: { apiKeyAuth: inputs.datadogApiKey } }))
+    const configuration = v1.createConfiguration({ authMethods: { apiKeyAuth: inputs.datadogApiKey } })
+
+    if (process.env.DD_SITE) {
+      v1.setServerVariables(configuration, {
+        site: process.env.DD_SITE,
+      })
+    }
+
+    const metrics = new v1.MetricsApi(configuration)
     const accepted = await metrics.submitMetrics({ body: { series } })
     core.info(`sent as ${JSON.stringify(accepted)}`)
   }


### PR DESCRIPTION
Send metrics to a different DataDog server such as the `eu` instance if the DD_SITE environment variable is set in the job definition. 

For example:

```yaml
jobs:
  send:
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - uses: int128/datadog-actions-metrics@v1
        with:
          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
          collect-job-metrics: true
        env:
          DD_SITE: "datadoghq.eu"
```

I'm open to changing DD_SITE from an environment variable to an input value such as "datadog-site" to be consistent with the rest of the inputs. Let me know if that is a better direction.

## Reference

@DataDog/datadog-api-client-typescript: [changing server](https://github.com/DataDog/datadog-api-client-typescript/tree/v1.0.0-beta.6#changing-server)