### PR TITLE
send metrics to different datadog server endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Name | Type | Description
 `github-token` | optional | GitHub token to get jobs and steps if needed. Default to `github.token`
 `github-token-rate-limit-metrics` | optional | GitHub token for rate limit metrics. Default to `github.token`
 `datadog-api-key` | optional | Datadog API key. If not set, this action does not send metrics actually
+`datadog-site` | optional | Datadog Server name such as "datadoghq.eu", "ddog-gov.com", "us3.datadoghq.com".
 `collect-job-metrics` | optional | Collect metrics of jobs and steps. Default to `false`
 
 Note that `collect-job-metrics-for-only-default-branch` is no longer supported.

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,9 @@ inputs:
   datadog-api-key:
     description: Datadog API key (dry-run if not set)
     required: false
+  datadog-site:
+    description: Datadog Site name if different than datadoghq.com.
+    required: false
   collect-job-metrics:
     description: Collect metrics of jobs and steps
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ const main = async (): Promise<void> => {
     githubToken: core.getInput('github-token', { required: true }),
     githubTokenForRateLimitMetrics: core.getInput('github-token-rate-limit-metrics', { required: true }),
     datadogApiKey: core.getInput('datadog-api-key') || undefined,
+    datadogSite: core.getInput('datadog-site') || undefined,
     collectJobMetrics: core.getBooleanInput('collect-job-metrics'),
   })
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,6 +13,7 @@ type Inputs = {
   githubToken: string
   githubTokenForRateLimitMetrics: string
   datadogApiKey?: string
+  datadogSite?: string
   collectJobMetrics: boolean
 }
 
@@ -80,7 +81,17 @@ const submitMetrics = async (series: Series[], inputs: Inputs) => {
   core.startGroup(`Send metrics to Datadog ${dryRun ? '(dry-run)' : ''}`)
   core.info(JSON.stringify(series, undefined, 2))
   if (!dryRun) {
-    const metrics = new v1.MetricsApi(v1.createConfiguration({ authMethods: { apiKeyAuth: inputs.datadogApiKey } }))
+    const configuration = v1.createConfiguration({
+      authMethods: { apiKeyAuth: inputs.datadogApiKey },
+    })
+
+    if (inputs.datadogSite) {
+      v1.setServerVariables(configuration, {
+        site: inputs.datadogSite,
+      })
+    }
+
+    const metrics = new v1.MetricsApi(configuration)
     const accepted = await metrics.submitMetrics({ body: { series } })
     core.info(`sent as ${JSON.stringify(accepted)}`)
   }


### PR DESCRIPTION
Send metrics to a different DataDog site such as the `eu` site if the datadog-site variable is set in the job definition. 

For example:

```yaml
jobs:
  send:
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - uses: int128/datadog-actions-metrics@v1
        with:
          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
          datadog-site: "datadoghq.eu"
          collect-job-metrics: true
```

## Reference

@DataDog/datadog-api-client-typescript: [changing server](https://github.com/DataDog/datadog-api-client-typescript/tree/v1.0.0-beta.6#changing-server)