### PR TITLE
Fix label tag if PR has multiple labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ It has the following tags:
 - `draft` = `true` or `false`
 - `base_ref`
 - `head_ref`
-- `label` = label(s) of the pull request
 
 
 ### Pull request (closed)
@@ -215,8 +214,11 @@ It has the following tags:
 - `draft` = `true` or `false`
 - `base_ref`
 - `head_ref`
-- `label` = label(s) of the pull request
+- `label` = label(s) of a pull request
 - `merged` = `true` or `false`
+
+You can aggregate a metric by a label in Datadog.
+If a pull request has multiple labels, this action sends the metrics for each label.
 
 
 ### Push

--- a/src/pullRequest/expand.ts
+++ b/src/pullRequest/expand.ts
@@ -1,0 +1,13 @@
+import { Series } from '@datadog/datadog-api-client/dist/packages/datadog-api-client-v1/models/Series'
+
+export const expandSeriesByLabels = (series: Series[], labels: { name: string }[]): Series[] => {
+  if (labels.length === 0) {
+    return series
+  }
+  return series.flatMap((s) =>
+    labels.map((label) => ({
+      ...s,
+      tags: [...(s.tags ?? []), `label:${label.name}`],
+    }))
+  )
+}

--- a/tests/pullRequest/expand.test.ts
+++ b/tests/pullRequest/expand.test.ts
@@ -1,0 +1,80 @@
+import { Series } from '@datadog/datadog-api-client/dist/packages/datadog-api-client-v1/models/Series'
+import { expandSeriesByLabels } from '../../src/pullRequest/expand'
+
+test('empty', () => {
+  expect(expandSeriesByLabels([], [])).toStrictEqual([])
+})
+
+test('expand series by no label', () => {
+  const series: Series[] = [
+    {
+      metric: 'github.actions.pull_request_closed.total',
+      points: [[1579721588, 1]],
+    },
+    {
+      metric: 'github.actions.pull_request_closed.commits',
+      points: [[1579721588, 2]],
+    },
+  ]
+  expect(expandSeriesByLabels(series, [])).toStrictEqual(series)
+})
+
+test('expand series by 1 label', () => {
+  const series: Series[] = [
+    {
+      metric: 'github.actions.pull_request_closed.total',
+      points: [[1579721588, 1]],
+    },
+    {
+      metric: 'github.actions.pull_request_closed.commits',
+      points: [[1579721588, 2]],
+    },
+  ]
+  expect(expandSeriesByLabels(series, [{ name: 'app' }])).toStrictEqual([
+    {
+      metric: 'github.actions.pull_request_closed.total',
+      points: [[1579721588, 1]],
+      tags: ['label:app'],
+    },
+    {
+      metric: 'github.actions.pull_request_closed.commits',
+      points: [[1579721588, 2]],
+      tags: ['label:app'],
+    },
+  ])
+})
+
+test('expand series by 2 labels', () => {
+  const series: Series[] = [
+    {
+      metric: 'github.actions.pull_request_closed.total',
+      points: [[1579721588, 1]],
+    },
+    {
+      metric: 'github.actions.pull_request_closed.commits',
+      points: [[1579721588, 2]],
+    },
+  ]
+  expect(expandSeriesByLabels(series, [{ name: 'app' }, { name: 'critical' }])).toStrictEqual([
+    {
+      metric: 'github.actions.pull_request_closed.total',
+      points: [[1579721588, 1]],
+      tags: ['label:app'],
+    },
+    {
+      metric: 'github.actions.pull_request_closed.total',
+      points: [[1579721588, 1]],
+      tags: ['label:critical'],
+    },
+    {
+      metric: 'github.actions.pull_request_closed.commits',
+      points: [[1579721588, 2]],
+      tags: ['label:app'],
+    },
+    {
+      metric: 'github.actions.pull_request_closed.commits',
+      points: [[1579721588, 2]],
+      tags: ['label:critical'],
+    },
+  ])
+})


### PR DESCRIPTION
This PR will fix the `label` tag when a pull request has multiple labels.

## Problem to solve
Currently, when a pull request has multiple labels, Datadog shows `label` tag as a combination of labels. For example, a pull request has `foo` and `bar`, Datadog shows `label:foo,bar`.

For actual use-case, I think it would be nice to analyze a pull request by a label, not combination of labels.

## Solution
Send the metrics for each label.

## Caveat
This may increase the charge of custom metrics. For most cases, we add label(s) after PR creation, so I removed `label` from the PR open metrics.
