### PR TITLE
Don't send label tag by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ It has the following tags:
 - `label` = label(s) of a pull request
 - `merged` = `true` or `false`
 
-You can aggregate a metric by a label in Datadog.
+You can set `send-pull-request-labels` to use `label` tag in Datadog.
 If a pull request has multiple labels, this action sends the metrics for each label.
+This action does not send labels by default from the cost perspective of the custom metrics.
 
 
 ### Push
@@ -266,6 +267,7 @@ Name | Default | Description
 `github-token-rate-limit-metrics` | `github.token` | GitHub token for rate limit metrics
 `datadog-api-key` | - | Datadog API key. If not set, this action does not send metrics actually
 `datadog-site` | - | Datadog Server name such as `datadoghq.eu`, `ddog-gov.com`, `us3.datadoghq.com`
+`send-pull-request-labels` | `false` | Send pull request labels as Datadog tags
 `collect-job-metrics` | `false` | Collect metrics of jobs and steps
 
 Note that `collect-job-metrics-for-only-default-branch` is no longer supported.

--- a/action.yaml
+++ b/action.yaml
@@ -10,16 +10,23 @@ inputs:
     description: GitHub token for rate limit metrics
     default: ${{ github.token }}
     required: true
+
   datadog-api-key:
     description: Datadog API key (dry-run if not set)
     required: false
   datadog-site:
     description: Datadog Site name if different than datadoghq.com.
     required: false
+
   collect-job-metrics:
     description: Collect metrics of jobs and steps
     required: false
     default: 'false'
+  send-pull-request-labels:
+    description: Send pull request labels as Datadog tags
+    required: false
+    default: 'false'
+
   collect-job-metrics-for-only-default-branch:
     description: No longer supported
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ const main = async (): Promise<void> => {
     datadogApiKey: core.getInput('datadog-api-key') || undefined,
     datadogSite: core.getInput('datadog-site') || undefined,
     collectJobMetrics: core.getBooleanInput('collect-job-metrics'),
+    sendPullRequestLabels: core.getBooleanInput('send-pull-request-labels'),
   })
 }
 

--- a/src/pullRequest/metrics.ts
+++ b/src/pullRequest/metrics.ts
@@ -60,7 +60,15 @@ export const computePullRequestOpenedMetrics = (e: PullRequestOpenedEvent): Seri
   ]
 }
 
-export const computePullRequestClosedMetrics = (e: PullRequestClosedEvent, pr?: ClosedPullRequest): Series[] => {
+type ClosedMetricsOptions = {
+  sendPullRequestLabels: boolean
+}
+
+export const computePullRequestClosedMetrics = (
+  e: PullRequestClosedEvent,
+  pr: ClosedPullRequest | undefined,
+  options: ClosedMetricsOptions
+): Series[] => {
   const tags = computeCommonTags(e)
   tags.push(`merged:${String(e.pull_request.merged)}`)
   const t = unixTime(e.pull_request.closed_at)
@@ -128,9 +136,12 @@ export const computePullRequestClosedMetrics = (e: PullRequestClosedEvent, pr?: 
     )
   }
 
-  // Datadog treats a tag as combination of values.
-  // For example, if we send a metric with tags `label:foo` and `label:bar`, Datadog will show `label:foo,bar`.
-  return expandSeriesByLabels(series, e.pull_request.labels)
+  if (options.sendPullRequestLabels) {
+    // Datadog treats a tag as combination of values.
+    // For example, if we send a metric with tags `label:foo` and `label:bar`, Datadog will show `label:foo,bar`.
+    return expandSeriesByLabels(series, e.pull_request.labels)
+  }
+  return series
 }
 
 const unixTime = (s: string): number => Date.parse(s) / 1000

--- a/src/run.ts
+++ b/src/run.ts
@@ -17,6 +17,7 @@ type Inputs = {
   datadogApiKey?: string
   datadogSite?: string
   collectJobMetrics: boolean
+  sendPullRequestLabels: boolean
 }
 
 export const run = async (context: GitHubContext, inputs: Inputs): Promise<void> => {
@@ -85,7 +86,7 @@ const handlePullRequest = async (e: PullRequestEvent, context: GitHubContext, in
     } catch (error) {
       core.warning(`Could not get the pull request: ${String(error)}`)
     }
-    return computePullRequestClosedMetrics(e, closedPullRequest)
+    return computePullRequestClosedMetrics(e, closedPullRequest, inputs)
   }
 }
 

--- a/tests/pullRequest/metrics.test.ts
+++ b/tests/pullRequest/metrics.test.ts
@@ -9,11 +9,15 @@ test('computePullRequestOpenedMetrics', () => {
 })
 
 test('computePullRequestClosedMetrics', () => {
-  const series = computePullRequestClosedMetrics(examplePullRequestClosedEvent)
+  const series = computePullRequestClosedMetrics(examplePullRequestClosedEvent, undefined, {
+    sendPullRequestLabels: true,
+  })
   expect(series).toMatchSnapshot()
 })
 
 test('computePullRequestClosedMetricsWithQuery', () => {
-  const series = computePullRequestClosedMetrics(examplePullRequestClosedEvent, exampleClosedPullRequest)
+  const series = computePullRequestClosedMetrics(examplePullRequestClosedEvent, exampleClosedPullRequest, {
+    sendPullRequestLabels: true,
+  })
   expect(series).toMatchSnapshot()
 })

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -53,6 +53,7 @@ test('workflow_run with collectJobMetrics', async () => {
       githubTokenForRateLimitMetrics: 'GITHUB_TOKEN',
       datadogApiKey: 'DATADOG_API_KEY',
       collectJobMetrics: true,
+      sendPullRequestLabels: false,
     }
   )
   expect(getOctokit).toBeCalledWith('GITHUB_TOKEN')
@@ -78,6 +79,7 @@ test('workflow_run', async () => {
       githubTokenForRateLimitMetrics: 'GITHUB_TOKEN',
       datadogApiKey: 'DATADOG_API_KEY',
       collectJobMetrics: false,
+      sendPullRequestLabels: false,
     }
   )
   expect(getOctokit).toBeCalledWith('GITHUB_TOKEN')
@@ -103,6 +105,7 @@ test('pull_request_opened', async () => {
       githubTokenForRateLimitMetrics: 'GITHUB_TOKEN',
       datadogApiKey: 'DATADOG_API_KEY',
       collectJobMetrics: false,
+      sendPullRequestLabels: false,
     }
   )
   expect(getOctokit).toBeCalledWith('GITHUB_TOKEN')
@@ -126,6 +129,7 @@ test('pull_request_closed', async () => {
       githubTokenForRateLimitMetrics: 'GITHUB_TOKEN',
       datadogApiKey: 'DATADOG_API_KEY',
       collectJobMetrics: false,
+      sendPullRequestLabels: true,
     }
   )
   expect(getOctokit).toBeCalledWith('GITHUB_TOKEN')


### PR DESCRIPTION
From the cost perspective of Datadog custom metrics, it would be nice to switch label tag.

## Breaking change
This action will not send a label tag (on pull request closed) by default. You need to explicitly set the option:

```yaml
with:
  send-pull-request-labels: true
```
