### PR TITLE
Add `github.actions.schedule.queued_workflow_run.total`

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 * * * *' # hourly
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This action handles the following events:
 - workflow_run event
 - pull_request event
 - push event
+- schedule event
 
 It ignores other events.
 
@@ -273,6 +274,22 @@ It has the following tags:
 - `deleted` = `true` or `false`
 - `forced` = `true` or `false`
 - `default_branch` = `true` or `false`
+
+
+## Metrics for schedule event
+
+### Workflow run
+
+This action sends the following metrics:
+
+- `github.actions.schedule.queued_workflow_run.total` (gauge)
+
+It has the following tags:
+
+- `repository_owner`
+- `repository_name`
+
+It is useful for monitoring self-hosted runners.
 
 
 ## Metrics for all supported events

--- a/src/schedule/metrics.ts
+++ b/src/schedule/metrics.ts
@@ -1,0 +1,20 @@
+import { Series } from '@datadog/datadog-api-client/dist/packages/datadog-api-client-v1/models/Series'
+import { GitHubContext, ListWorkflowRunsForRepoRateLimitResponse } from '../types'
+
+export const computeScheduleMetrics = (
+  context: GitHubContext,
+  queuedWorkflowRuns: ListWorkflowRunsForRepoRateLimitResponse,
+  now: Date
+): Series[] => {
+  const tags = [`repository_owner:${context.repo.owner}`, `repository_name:${context.repo.repo}`]
+  const t = now.getTime() / 1000
+  return [
+    {
+      host: 'github.com',
+      tags,
+      metric: 'github.actions.schedule.queued_workflow_run.total',
+      type: 'gauge',
+      points: [[t, queuedWorkflowRuns.data.total_count]],
+    },
+  ]
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,4 +6,6 @@ export type GitHubContext = Pick<Context, 'eventName' | 'payload' | 'repo'>
 
 export type Octokit = InstanceType<typeof GitHub>
 
+export type ListWorkflowRunsForRepoRateLimitResponse = Endpoints['GET /repos/{owner}/{repo}/actions/runs']['response']
+
 export type RateLimitResponse = Endpoints['GET /rate_limit']['response']


### PR DESCRIPTION
This will add a metric for monitoring self-hosted runners. It is still experimental.
https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository