### PR TITLE
Enable compress of metrics payload

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -33,6 +33,11 @@ jobs:
 
       - name: smoke test
         uses: ./
+        # FIXME: do not merge into main
+        with:
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
+          collect-job-metrics: true
+          collect-step-metrics: true
 
   generate:
     runs-on: ubuntu-latest

--- a/src/run.ts
+++ b/src/run.ts
@@ -140,6 +140,9 @@ const submitMetrics = async (series: v1.Series[], inputs: Inputs) => {
     authMethods: {
       apiKeyAuth: inputs.datadogApiKey,
     },
+    httpConfig: {
+      compress: true,
+    },
   })
   if (inputs.datadogSite) {
     client.setServerVariables(configuration, {


### PR DESCRIPTION
This would eliminate the limit of maximum payload size.

>https://datadoghq.dev/datadog-api-client-typescript/classes/v1.MetricsApi.html#submitMetrics
>The metrics end-point allows you to post time-series data that can be graphed on Datadog’s dashboards. The maximum payload size is 3.2 megabytes (3200000 bytes). Compressed payloads must have a decompressed size of less than 62 megabytes (62914560 bytes).

## Issue
- https://github.com/int128/datadog-actions-metrics/issues/521
