### PR TITLE
Add `received_shutdown_signal_error_total` metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ This action sends the following metrics if `collect-job-metrics` is enabled.
 - `github.actions.job.lost_communication_with_server_error_total`
   - Count of "lost communication with the server" errors of self-hosted runners.
     See the issue [#444](https://github.com/int128/datadog-actions-metrics/issues/444) for details
+- `github.actions.job.received_shutdown_signal_error_total`
+  - Count of "The runner has received a shutdown signal" errors of self-hosted runners.
 
 It has the following tags:
 

--- a/src/workflowRun/metrics.ts
+++ b/src/workflowRun/metrics.ts
@@ -158,6 +158,16 @@ export const computeJobMetrics = (
       })
     }
 
+    if (checkRun.annotations.nodes.some((a) => isReceivedShutdownSignalError(a.message))) {
+      series.push({
+        host: 'github.com',
+        tags,
+        metric: 'github.actions.job.received_shutdown_signal_error_total',
+        type: 'count',
+        points: [[completedAt, 1]],
+      })
+    }
+
     if (checkRun.steps.nodes.length > 0) {
       const firstStepStartedAt = Math.min(...checkRun.steps.nodes.map((s) => unixTime(s.startedAt)))
       const queued = firstStepStartedAt - startedAt
@@ -175,6 +185,9 @@ export const computeJobMetrics = (
 
 export const isLostCommunicationWithServerError = (message: string): boolean =>
   /^The self-hosted runner: .+? lost communication with the server./.test(message)
+
+export const isReceivedShutdownSignalError = (message: string): boolean =>
+  message.startsWith('The runner has received a shutdown signal.')
 
 export const computeStepMetrics = (
   e: WorkflowRunCompletedEvent,

--- a/tests/workflowRun/metrics.test.ts
+++ b/tests/workflowRun/metrics.test.ts
@@ -4,6 +4,7 @@ import {
   computeStepMetrics,
   computeWorkflowRunMetrics,
   isLostCommunicationWithServerError,
+  isReceivedShutdownSignalError,
 } from '../../src/workflowRun/metrics'
 import { exampleCompletedCheckSuite } from './fixtures/completedCheckSuite'
 import { exampleWorkflowRunEvent } from './fixtures/workflowRunEvent'
@@ -41,5 +42,18 @@ describe('isLostCommunicationWithServerError', () => {
   })
   test('not related error', () => {
     expect(isLostCommunicationWithServerError(`Process exit 1`)).toBeFalsy()
+  })
+})
+
+describe('isReceivedShutdownSignalError', () => {
+  test('matched', () => {
+    expect(
+      isReceivedShutdownSignalError(
+        `The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.`
+      )
+    ).toBeTruthy()
+  })
+  test('not related error', () => {
+    expect(isReceivedShutdownSignalError(`Process exit 1`)).toBeFalsy()
   })
 })


### PR DESCRIPTION
This will add a metric for the following error:

>The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
The operation was canceled.

## Related
- https://github.com/philips-labs/terraform-aws-github-runner/issues/931