### PR TITLE
Add `pull_request_number` tag to workflow metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ It has the following tags:
 - `sender_type` = either `Bot`, `User` or `Organization`
 - `branch`
 - `default_branch` = `true` or `false`
+- `pull_request_number`
+  - Pull request(s) which triggered the workflow
 - `conclusion`
 
 See also the actual metrics in the [E2E test](https://github.com/int128/datadog-actions-metrics/actions/workflows/e2e.yaml).
@@ -154,6 +156,8 @@ It has the following tags:
 - `sender_type` = either `Bot`, `User` or `Organization`
 - `branch`
 - `default_branch` = `true` or `false`
+- `pull_request_number`
+  - Pull request(s) which triggered the workflow
 - `job_name`
 - `job_id`
 - `conclusion`
@@ -184,6 +188,8 @@ It has the following tags:
 - `sender_type` = either `Bot`, `User` or `Organization`
 - `branch`
 - `default_branch` = `true` or `false`
+- `pull_request_number`
+  - Pull request(s) which triggered the workflow
 - `job_name`
 - `job_id`
 - `step_name`

--- a/src/workflowRun/metrics.ts
+++ b/src/workflowRun/metrics.ts
@@ -15,6 +15,7 @@ const computeCommonTags = (e: WorkflowRunCompletedEvent): string[] => [
   `sender_type:${e.sender.type}`,
   `branch:${e.workflow_run.head_branch}`,
   `default_branch:${(e.workflow_run.head_branch === e.repository.default_branch).toString()}`,
+  ...e.workflow_run.pull_requests.map((pull) => `pull_request_number:${pull.number}`),
 ]
 
 export type WorkflowRunJobStepMetrics = {


### PR DESCRIPTION
## Issue
- https://github.com/int128/datadog-actions-metrics/issues/563

## E2E test
https://github.com/int128/datadog-actions-metrics/actions/runs/4371506425/jobs/7647437073

```json
        "pull_request_number:597",
```
