### PR TITLE
Fix metrics depending on check run annotations

### DIFF
--- a/src/queries/getCheckSuite.ts
+++ b/src/queries/getCheckSuite.ts
@@ -33,10 +33,10 @@ export type CompletedCheckSuite = {
 }
 
 type CompletedCheckRun = Pick<CheckRun, 'databaseId'> & {
-    annotations: {
-      nodes: Pick<CheckAnnotation, 'message'>[]
-    }
+  annotations: {
+    nodes: Pick<CheckAnnotation, 'message'>[]
   }
+}
 
 export const getCompletedCheckSuite = async (
   o: Octokit,
@@ -51,7 +51,7 @@ export const getCompletedCheckSuite = async (
   }
 }
 
-const extractCheckRuns = (r: GetCheckSuiteQuery): CompletedCheckSuite['node']['checkRuns'] => {
+export const extractCheckRuns = (r: GetCheckSuiteQuery): CompletedCheckSuite['node']['checkRuns'] => {
   assert(r.node != null)
   assert.strictEqual(r.node.__typename, 'CheckSuite')
 
@@ -68,6 +68,13 @@ const extractCheckRuns = (r: GetCheckSuiteQuery): CompletedCheckSuite['node']['c
       }
       annotations.push(annotation)
     }
+
+    checkRuns.push({
+      ...checkRun,
+      annotations: {
+        nodes: annotations,
+      },
+    })
   }
   return { nodes: checkRuns }
 }

--- a/tests/queries/getCheckSuite.test.ts
+++ b/tests/queries/getCheckSuite.test.ts
@@ -1,0 +1,78 @@
+import { extractCheckRuns } from '../../src/queries/getCheckSuite'
+
+describe('extractCheckRuns', () => {
+  it('should return same length of nodes', () => {
+    const checkRuns = extractCheckRuns({
+      node: {
+        __typename: 'CheckSuite',
+        checkRuns: {
+          nodes: [
+            {
+              databaseId: 20679829243,
+              annotations: {
+                nodes: [],
+              },
+            },
+            {
+              databaseId: 20679829416,
+              annotations: {
+                nodes: [],
+              },
+            },
+            {
+              databaseId: 20679850772,
+              annotations: {
+                nodes: [],
+              },
+            },
+          ],
+        },
+      },
+    })
+    expect(checkRuns.nodes).toHaveLength(3)
+  })
+
+  it('should return same length of annotations', () => {
+    const checkRuns = extractCheckRuns({
+      node: {
+        __typename: 'CheckSuite',
+        checkRuns: {
+          nodes: [
+            {
+              databaseId: 20679829243,
+              annotations: {
+                nodes: [
+                  {
+                    message: 'test',
+                  },
+                  {
+                    message: 'test',
+                  },
+                ],
+              },
+            },
+            {
+              databaseId: 20679829416,
+              annotations: {
+                nodes: [
+                  {
+                    message: 'test',
+                  },
+                ],
+              },
+            },
+            {
+              databaseId: 20679850772,
+              annotations: {
+                nodes: [],
+              },
+            },
+          ],
+        },
+      },
+    })
+    expect(checkRuns.nodes[0].annotations.nodes).toHaveLength(2)
+    expect(checkRuns.nodes[1].annotations.nodes).toHaveLength(1)
+    expect(checkRuns.nodes[2].annotations.nodes).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Bug
The following metrics are not sent since [v1.68.0](https://github.com/int128/datadog-actions-metrics/releases/tag/v1.68.0):

- `github.actions.job.lost_communication_with_server_error_total`
- `github.actions.job.received_shutdown_signal_error_total`

Follow up https://github.com/int128/datadog-actions-metrics/pull/964.
