### PR TITLE
Add `filtered-metrics` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ You can set the following inputs:
 | `collect-job-metrics`             | `false`        | Collect job metrics                                                             |
 | `collect-step-metrics`            | `false`        | Collect step metrics                                                            |
 | `disable-distribution-metrics`    | `false`        | If true, do not send the distribution metrics                                   |
+| `filtered-metrics`                | -              | Metrics to be sent. Defaults to all metrics                                     |
 
 ### Proxy
 

--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ inputs:
     required: false
     default: 'false'
 
+  filtered-metrics:
+    description: Metrics to collect
+    required: false
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ type Inputs = {
   datadogSite?: string
   datadogTags: string[]
   disableDistributionMetrics: boolean
+  filteredMetrics: string[]
 }
 
 export type MetricsClient = {
@@ -15,11 +16,12 @@ export type MetricsClient = {
 }
 
 class DryRunMetricsClient implements MetricsClient {
-  constructor(private readonly tags: string[]) {}
+  constructor(private readonly tags: string[], private readonly filteredMetrics: string[]) {}
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async submitMetrics(series: v1.Series[], description: string): Promise<void> {
     series = injectTags(series, this.tags)
+    series = filterMetrics(series, this.filteredMetrics)
     core.startGroup(`Metrics payload (dry-run) (${description})`)
     core.info(JSON.stringify(series, undefined, 2))
     core.endGroup()
@@ -28,6 +30,7 @@ class DryRunMetricsClient implements MetricsClient {
   // eslint-disable-next-line @typescript-eslint/require-await
   async submitDistributionPoints(series: v1.DistributionPointsSeries[], description: string): Promise<void> {
     series = injectTags(series, this.tags)
+    series = filterMetrics(series, this.filteredMetrics)
     core.startGroup(`Distribution points payload (dry-run) (${description})`)
     core.info(JSON.stringify(series, undefined, 2))
     core.endGroup()
@@ -39,10 +42,12 @@ class RealMetricsClient implements MetricsClient {
     private readonly metricsApi: v1.MetricsApi,
     private readonly tags: string[],
     private readonly disableDistributionMetrics: boolean,
+    private readonly filteredMetrics: string[]
   ) {}
 
   async submitMetrics(series: v1.Series[], description: string): Promise<void> {
     series = injectTags(series, this.tags)
+    series = filterMetrics(series, this.filteredMetrics)
     core.startGroup(`Metrics payload (${description})`)
     core.info(JSON.stringify(series, undefined, 2))
     core.endGroup()
@@ -53,6 +58,7 @@ class RealMetricsClient implements MetricsClient {
 
   async submitDistributionPoints(series: v1.DistributionPointsSeries[], description: string): Promise<void> {
     series = injectTags(series, this.tags)
+    series = filterMetrics(series, this.filteredMetrics)
     core.startGroup(`Distribution points payload (${description})`)
     core.info(JSON.stringify(series, undefined, 2))
     core.endGroup()
@@ -82,7 +88,7 @@ export const filterMetrics = <S extends { metric: string }>(series: S[], filtere
 
 export const createMetricsClient = (inputs: Inputs): MetricsClient => {
   if (inputs.datadogApiKey === undefined) {
-    return new DryRunMetricsClient(inputs.datadogTags)
+    return new DryRunMetricsClient(inputs.datadogTags, inputs.filteredMetrics)
   }
 
   const configuration = client.createConfiguration({
@@ -96,7 +102,7 @@ export const createMetricsClient = (inputs: Inputs): MetricsClient => {
       site: inputs.datadogSite,
     })
   }
-  return new RealMetricsClient(new v1.MetricsApi(configuration), inputs.datadogTags, inputs.disableDistributionMetrics)
+  return new RealMetricsClient(new v1.MetricsApi(configuration), inputs.datadogTags, inputs.disableDistributionMetrics, inputs.filteredMetrics)
 }
 
 const createHttpLibraryIfHttpsProxy = () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -73,6 +73,13 @@ export const injectTags = <S extends { tags?: string[] }>(series: S[], tags: str
   return series.map((s) => ({ ...s, tags: [...(s.tags ?? []), ...tags] }))
 }
 
+export const filterMetrics = <S extends { metric: string }>(series: S[], filteredMetrics: string[]): S[] => {
+  if (filteredMetrics.length === 0) {
+    return series
+  }
+  return series.filter((s) => filteredMetrics.includes(s.metric))
+}
+
 export const createMetricsClient = (inputs: Inputs): MetricsClient => {
   if (inputs.datadogApiKey === undefined) {
     return new DryRunMetricsClient(inputs.datadogTags)

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ const main = async (): Promise<void> => {
     collectStepMetrics: core.getBooleanInput('collect-step-metrics'),
     sendPullRequestLabels: core.getBooleanInput('send-pull-request-labels'),
     disableDistributionMetrics: core.getBooleanInput('disable-distribution-metrics'),
+    filteredMetrics: core.getMultilineInput('filtered-metrics'),
   })
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,6 +19,7 @@ type Inputs = {
   collectStepMetrics: boolean
   sendPullRequestLabels: boolean
   disableDistributionMetrics: boolean
+  filteredMetrics: string[]
 }
 
 export const run = async (context: GitHubContext, inputs: Inputs): Promise<void> => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -16,8 +16,16 @@ describe('filterMetrics', () => {
     const series = [{ metric: 'metric1' }]
     expect(filterMetrics(series, [])).toEqual(series)
   })
-  it('should return series without filteredMetrics', () => {
+  it('should return series with filteredMetrics', () => {
     const series = [{ metric: 'metric1' }, { metric: 'metric2' }]
     expect(filterMetrics(series, ['metric2'])).toEqual([{ metric: 'metric2' }])
+  })
+  it('should return series without filteredMetrics', () => {
+    const series = [{ metric: 'metric1' }, { metric: 'metric2' }]
+    expect(filterMetrics(series, ['metric3'])).toEqual([])
+  })
+  it('should return series with multiple filteredMetrics', () => {
+    const series = [{ metric: 'metric1' }, { metric: 'metric2' }, { metric: 'metric3' }]
+    expect(filterMetrics(series, ['metric2', 'metric3'])).toEqual([{ metric: 'metric2' }, { metric: 'metric3' }])
   })
 })

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,4 +1,4 @@
-import { injectTags } from '../src/client'
+import { injectTags, filterMetrics } from '../src/client'
 
 describe('injectTags', () => {
   it('should return series if tags is empty', () => {
@@ -8,5 +8,16 @@ describe('injectTags', () => {
   it('should return series with tags', () => {
     const series = [{ tags: ['tag1:value1'] }]
     expect(injectTags(series, ['tag2:value2'])).toEqual([{ tags: ['tag1:value1', 'tag2:value2'] }])
+  })
+})
+
+describe('filterMetrics', () => {
+  it('should return series if filteredMetrics is empty', () => {
+    const series = [{ metric: 'metric1' }]
+    expect(filterMetrics(series, [])).toEqual(series)
+  })
+  it('should return series without filteredMetrics', () => {
+    const series = [{ metric: 'metric1' }, { metric: 'metric2' }]
+    expect(filterMetrics(series, ['metric2'])).toEqual([{ metric: 'metric2' }])
   })
 })

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -51,6 +51,7 @@ test('workflow_run with collectJobMetrics', async () => {
       collectStepMetrics: true,
       sendPullRequestLabels: false,
       disableDistributionMetrics: false,
+      filteredMetrics: [],
     },
   )
   expect(getOctokit).toHaveBeenCalledWith('GITHUB_TOKEN')
@@ -77,6 +78,7 @@ test('workflow_run', async () => {
       collectStepMetrics: false,
       sendPullRequestLabels: false,
       disableDistributionMetrics: false,
+      filteredMetrics: [],
     },
   )
   expect(getOctokit).toHaveBeenCalledWith('GITHUB_TOKEN')
@@ -103,6 +105,7 @@ test('pull_request_opened', async () => {
       collectStepMetrics: false,
       sendPullRequestLabels: false,
       disableDistributionMetrics: false,
+      filteredMetrics: [],
     },
   )
   expect(getOctokit).toHaveBeenCalledWith('GITHUB_TOKEN')
@@ -130,6 +133,7 @@ test('pull_request_closed', async () => {
       collectStepMetrics: false,
       sendPullRequestLabels: true,
       disableDistributionMetrics: false,
+      filteredMetrics: [],
     },
   )
   expect(getOctokit).toHaveBeenCalledWith('GITHUB_TOKEN')


### PR DESCRIPTION
This adds a `filtered-metrics` option. Only metrics included in the multiline
string should be sent out.

I've added some tests for the new function, but let me know if you'd like more exhaustive tests.

Is `included-metrics` a better name?

Ref: https://github.com/int128/datadog-actions-metrics/issues/1081
