### PR TITLE
Fix job error metrics

### DIFF
--- a/src/workflowRun/metrics.ts
+++ b/src/workflowRun/metrics.ts
@@ -235,7 +235,7 @@ export const computeJobMetrics = (
     }
 
     if (checkSuite) {
-      const checkRun = checkSuite.node.checkRuns.nodes.find((checkRun) => checkRun.databaseId === job.run_id)
+      const checkRun = checkSuite.node.checkRuns.nodes.find((checkRun) => checkRun.databaseId === job.id)
       if (checkRun) {
         if (checkRun.annotations.nodes.some((a) => isLostCommunicationWithServerError(a.message))) {
           series.push({


### PR DESCRIPTION
I noticed the following metrics are not available:

- `github.actions.job.lost_communication_with_server_error_total`
- `github.actions.job.received_shutdown_signal_error_total`

Follow up https://github.com/int128/datadog-actions-metrics/pull/964.
Since https://github.com/int128/datadog-actions-metrics/releases/tag/v1.68.0