### PR TITLE
Skip rate-limit metrics if GitHub API returned error

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -29,8 +29,12 @@ export const run = async (context: GitHubContext, inputs: Inputs): Promise<void>
 
   await handleEvent(metricsClient, context, inputs)
 
-  const rateLimit = await getRateLimitMetrics(context, inputs)
-  await metricsClient.submitMetrics(rateLimit, 'rate limit')
+  const rateLimit = await getRateLimitMetrics(context, inputs).catch((e) => {
+    core.warning(`Rate-limit metrics are not available: ${e}`)
+  })
+  if (rateLimit) {
+    await metricsClient.submitMetrics(rateLimit, 'rate-limit')
+  }
 }
 
 const handleEvent = async (metricsClient: MetricsClient, context: GitHubContext, inputs: Inputs) => {


### PR DESCRIPTION
Resolves https://github.com/int128/datadog-actions-metrics/issues/1205.