### PR TITLE
Add `pull_request_dequeued.*` metrics

### DIFF
--- a/src/pullRequest/handler.ts
+++ b/src/pullRequest/handler.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github'
 import { MetricsClient } from '../client.js'
 import { PullRequestEvent } from '@octokit/webhooks-types/schema.js'
 import { GitHubContext } from '../types.js'
-import { computePullRequestClosedMetrics, computePullRequestOpenedMetrics } from './metrics.js'
+import { computePullRequestClosedMetrics, computePullRequestOpenedMetrics, computePullRequestDequeuedMetrics } from './metrics.js'
 import { getPullRequestFirstCommit } from '../queries/getPullRequest.js'
 
 type Inputs = {
@@ -40,6 +40,10 @@ export const handlePullRequest = async (
       computePullRequestClosedMetrics(e, pullRequestFirstCommit, inputs),
       'pull request',
     )
+  }
+
+  if (e.action === 'dequeued') {
+    return await metricsClient.submitMetrics(computePullRequestDequeuedMetrics(e), 'pull request')
   }
 
   core.warning(`Not supported action ${e.action}`)

--- a/src/pullRequest/metrics.ts
+++ b/src/pullRequest/metrics.ts
@@ -1,5 +1,5 @@
 import { v1 } from '@datadog/datadog-api-client'
-import { PullRequestClosedEvent, PullRequestEvent, PullRequestOpenedEvent } from '@octokit/webhooks-types'
+import { PullRequestClosedEvent, PullRequestEvent, PullRequestOpenedEvent, PullRequestDequeuedEvent } from '@octokit/webhooks-types'
 import { PullRequestFirstCommit } from '../queries/getPullRequest.js'
 
 const computeCommonTags = (e: PullRequestEvent): string[] => {
@@ -150,6 +150,27 @@ export const computePullRequestClosedMetrics = (
   }
 
   return series
+}
+
+export const computePullRequestDequeuedMetrics = (e: PullRequestDequeuedEvent): v1.Series[] => {
+  const tags = computeCommonTags(e)
+  const t = unixTime(e.pull_request.updated_at)
+  return [
+    {
+      host: 'github.com',
+      tags,
+      metric: 'github.actions.pull_request_dequeued.total',
+      type: 'count',
+      points: [[t, 1]],
+    },
+    {
+      host: 'github.com',
+      tags,
+      metric: `github.actions.pull_request_dequeued.reason.${e.reason.toLowerCase()}_total`,
+      type: 'count',
+      points: [[t, 1]],
+    },
+  ]
 }
 
 const unixTime = (s: string): number => Date.parse(s) / 1000


### PR DESCRIPTION
This PR adds metrics to capture pull request `dequeued` events.

When a pull request is `dequeued`, it could be for a variety of reasons. The reasons are (UNKNOWN_REMOVAL_REASON, MANUAL, MERGE, MERGE_CONFLICT, CI_FAILURE, CI_TIMEOUT, ALREADY_MERGED, QUEUE_CLEARED, ROLL_BACK, BRANCH_PROTECTIONS, GIT_TREE_INVALID, INVALID_MERGE_COMMIT).

I would like to count how often a pull requests is dequeued for reasons like CI_FAILURE.

Adds
* `github.actions.pull_request_dequeued.total`
* `github.actions.pull_request_dequeued.reason.${reason}_total`.

Docs: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=dequeued#pull_request