### PR TITLE
Do not update int128/datadog-actions-metrics

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,5 +3,13 @@
     "github>int128/renovate-base",
     "github>int128/typescript-action-renovate-config",
     "helpers:pinGitHubActionDigests",
-  ]
+  ],
+  "packageRules": [
+    {
+      "description": "Do not update myself",
+      "matchFileNames": [".github/workflows/**"],
+      "matchDepNames": ["int128/datadog-actions-metrics"],
+      "enabled": false,
+    },
+  ],
 }

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,7 @@ jobs:
             core.info(`actor=${context.actor}`)
             core.info(`payload=${JSON.stringify(context.payload, undefined, 2)}`)
 
-      - uses: int128/datadog-actions-metrics@2795b543f2a0036f02dc60ce8088688041bb7295 # v1.98.0
+      - uses: int128/datadog-actions-metrics@v1
         with:
           datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
           collect-job-metrics: true


### PR DESCRIPTION
Pin the version of e2e workflow to v1 and suppress the updates like https://github.com/int128/datadog-actions-metrics/pull/1257